### PR TITLE
Added wasmtime dotnet Nuget package wrapper

### DIFF
--- a/WASIDotNetConsoleApp/WASIDotNetConsoleApp.csproj
+++ b/WASIDotNetConsoleApp/WASIDotNetConsoleApp.csproj
@@ -7,4 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="wasmtime" Version="19.0.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This pull request includes a change to the `WASIDotNetConsoleApp/WASIDotNetConsoleApp.csproj` file. The change adds a new package reference to the project.

Wasmtime Nuget package (The .NET embedding of Wasmtime): This is a .NET library that provides an interface to the Wasmtime runtime. It allows .NET applications to load and execute WebAssembly modules. It's like a bridge between your .NET application and the Wasmtime runtime.