### PR TITLE
Created 2 sample WASI console apps to be used with wasmtime

### DIFF
--- a/WASIDotNetApp.sln
+++ b/WASIDotNetApp.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34525.116
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WASIDotNetConsoleApp", "WASIDotNetConsoleApp\WASIDotNetConsoleApp.csproj", "{D657DEA5-BB19-4A2C-9D43-BBAB754CA972}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WASIDotNetConsoleApp", "WASIDotNetConsoleApp\WASIDotNetConsoleApp.csproj", "{D657DEA5-BB19-4A2C-9D43-BBAB754CA972}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WASIDotNetConsoleTemplateApp", "WASIDotNetConsoleTemplateApp\WASIDotNetConsoleTemplateApp.csproj", "{6D8E0F39-34BB-49C8-A1F5-8B7CE4C906CC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{D657DEA5-BB19-4A2C-9D43-BBAB754CA972}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D657DEA5-BB19-4A2C-9D43-BBAB754CA972}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D657DEA5-BB19-4A2C-9D43-BBAB754CA972}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D8E0F39-34BB-49C8-A1F5-8B7CE4C906CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D8E0F39-34BB-49C8-A1F5-8B7CE4C906CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D8E0F39-34BB-49C8-A1F5-8B7CE4C906CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D8E0F39-34BB-49C8-A1F5-8B7CE4C906CC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WASIDotNetConsoleApp/Program.cs
+++ b/WASIDotNetConsoleApp/Program.cs
@@ -1,2 +1,26 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+﻿using System;
+using Wasmtime;
+
+using var engine = new Engine();
+
+// Uses 'WebAssembly Text Format' (AKA 'WAT') to define a simple WebAssembly module.
+// Text parameter: this WebAssembly module imports a function named "hello" and defines a function named "run" that calls "hello".
+// The "run" function is exported so it can be called from outside the WebAssembly module.
+using var module = Module.FromText(
+    engine,
+    "hello",
+    "(module (func $hello (import \"\" \"hello_csharp_code\")) (func (export \"run\") (call $hello)))"
+);
+
+using var linker = new Linker(engine);
+using var store = new Store(engine);
+
+linker.Define(
+    "",
+    "hello_csharp_code",
+    Function.FromCallback(store, () => Console.WriteLine("Hello from C#!"))
+);
+
+var instance = linker.Instantiate(store, module);
+var run = instance.GetAction("run")!;
+run();

--- a/WASIDotNetConsoleApp/WASIDotNetConsoleApp.csproj
+++ b/WASIDotNetConsoleApp/WASIDotNetConsoleApp.csproj
@@ -3,8 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+	<OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	<PublishTrimmed>true</PublishTrimmed>
+	<WasmSingleFileBundle>true</WasmSingleFileBundle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WASIDotNetConsoleTemplateApp/Program.cs
+++ b/WASIDotNetConsoleTemplateApp/Program.cs
@@ -1,0 +1,3 @@
+using System;
+
+Console.WriteLine("Hello, Wasi Console!");

--- a/WASIDotNetConsoleTemplateApp/Properties/AssemblyInfo.cs
+++ b/WASIDotNetConsoleTemplateApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+[assembly:System.Runtime.Versioning.SupportedOSPlatform("wasi")]

--- a/WASIDotNetConsoleTemplateApp/README.md
+++ b/WASIDotNetConsoleTemplateApp/README.md
@@ -1,0 +1,36 @@
+## .NET WASI app
+
+Pre-requisites:
+Required wasi-sdk installed. You can download it from https://github.com/WebAssembly/wasi-sdk/releases
+The Windows package is the one with the following extension wasi-sdk-22.0.m-mingw.tar.gz
+The mingw in the filename indicates that it's meant to be used with MinGW, a minimalist development environment for native Microsoft Windows application
+
+NOTE! This app does not work with MSBuild directly in VS. Use a command line separately:
+```
+cd C:\Projects\OSS\WASIDotNetApp\WASIDotNetConsoleTemplateApp\bin\Debug\net8.0\wasi-wasm\AppBundle
+wasmtime --dir . WASIDotNetConsoleTemplateApp.wasm
+```
+
+## Build
+
+You can build the app from Visual Studio or from the command-line:
+
+```
+dotnet build -c Debug/Release
+```
+
+After building the app, the result is in the `bin/$(Configuration)/net8.0/wasi-wasm/AppBundle` directory.
+
+## Run
+
+You can build the app from Visual Studio or the command-line:
+
+```
+dotnet run -c Debug/Release
+```
+
+Or directly start node from the AppBundle directory:
+
+```
+wasmtime bin/$(Configuration)/net8.0/browser-wasm/AppBundle/WASIDotNetConsoleTemplateApp.wasm
+```

--- a/WASIDotNetConsoleTemplateApp/WASIDotNetConsoleTemplateApp.csproj
+++ b/WASIDotNetConsoleTemplateApp/WASIDotNetConsoleTemplateApp.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
+    <OutputType>Exe</OutputType>
+    <PublishTrimmed>true</PublishTrimmed>
+	<WasmSingleFileBundle>true</WasmSingleFileBundle>
+  </PropertyGroup>
+</Project>

--- a/WASIDotNetConsoleTemplateApp/runtimeconfig.template.json
+++ b/WASIDotNetConsoleTemplateApp/runtimeconfig.template.json
@@ -1,0 +1,10 @@
+{
+    "wasmHostProperties": {
+        "perHostConfig": [
+            {
+                "name": "wasmtime",
+                "Host": "wasmtime"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `WASIDotNetApp.sln` solution, including the addition of a new project, `WASIDotNetConsoleTemplateApp`, and modifications to the existing `WASIDotNetConsoleApp` project. The changes primarily revolve around the integration of WebAssembly (Wasm) into the .NET solution and the introduction of the Wasmtime engine.